### PR TITLE
peco ることを増やした

### DIFF
--- a/.zsh/peco-sources/projects.zsh
+++ b/.zsh/peco-sources/projects.zsh
@@ -1,0 +1,19 @@
+function peco-move-projects() {
+    if [[ -v _bobpp_PROJECT_ROOT ]]; then
+        cd $(find $_bobpp_PROJECT_ROOT -type d -maxdepth 1 -mindepth 1 | peco)
+    else
+        echo 'not set $_bobpp_PROJECT_ROOT'
+    fi
+}
+
+function peco-open-code-projects() {
+    if [[ -v _bobpp_PROJECT_ROOT ]]; then
+        if [[ -n $(which code 2>/dev/null) ]]; then
+            code $(find $_bobpp_PROJECT_ROOT -type d -maxdepth 1 -mindepth 1 | peco)
+        else
+            echo 'require Visual Studio Code.'
+        fi
+    else
+        echo 'not set $_bobpp_PROJECT_ROOT'
+    fi
+}

--- a/.zsh/peco-sources/select-ghq.zsh
+++ b/.zsh/peco-sources/select-ghq.zsh
@@ -1,0 +1,7 @@
+function peco-select-ghq() {
+    if [[ -n $(which ghq 2>/dev/null) ]]; then
+        cd $(ghq root)/$(ghq list | peco)
+    else
+        echo "require ghq"
+    fi
+}

--- a/.zsh/peco-sources/select-history.zsh
+++ b/.zsh/peco-sources/select-history.zsh
@@ -5,11 +5,8 @@ function peco-select-history() {
     else
         tac="tail -r"
     fi
-    BUFFER=$(\history -n 1 | \
-        eval $tac | \
-        peco --query "$LBUFFER")
+    BUFFER="$(\history -n 1 | eval $tac | peco --query "$LBUFFER" | sed 's/\\n/\'$'\n/g')"
     CURSOR=$#BUFFER
     zle clear-screen
 }
 zle -N peco-select-history
-

--- a/.zshrc
+++ b/.zshrc
@@ -57,11 +57,17 @@ fi
 # load peco functions
 if [[ -n $(which peco 2>/dev/null) ]]; then
   for f (~/.zsh/peco-sources/*) source "${f}"
+
   bindkey '^r' peco-select-history
   bindkey '^g' peco-git-branch-checkout
-  if [[ -n $(which ghq 2>/dev/null) ]]; then
-    alias ghqr='cd $(ghq root)/$(ghq list | peco)'
-  fi
+  alias ghqp=peco-select-ghq
+  alias cdp=peco-move-projects
+  alias codep=peco-open-code-projects
+fi
+
+# load direnv
+if [[ -n $(which direnv 2>/dev/null) ]]; then
+  eval "$(direnv hook zsh)"
 fi
 
 # my theme


### PR DESCRIPTION
# peco-move-projects
`$_bobpp_PROJECT_ROOT` という謎の環境変数がある場合にのみ活用されるもの。
この変数は `direnv` で差し込むことを想定しています。

この変数が示すディレクトリ以下に現在のプロジェクトで使う各ディレクトリが置かれているという構成下において、cd するディレクトリを peco って選択できるようにした。

# peco-open-code-projects
`peco-move-projects` で cd するのを code で開く用に変えただけのもの。

# peco-select-ghq
これは https://github.com/bobpp/dotfiles/blob/bf2b15e245db43cd743d938fd2afcc2575541e81/.zshrc#L63 を移植しただけ